### PR TITLE
RD-1696: Remove 'production-ready' claim for UCEF

### DIFF
--- a/.changeset/rd-1696-remove-ucef-production-ready.md
+++ b/.changeset/rd-1696-remove-ucef-production-ready.md
@@ -1,0 +1,13 @@
+---
+"@appliedblockchain/silentdatarollup-core": minor
+"@appliedblockchain/silentdatarollup-custom-rpc": minor
+"@appliedblockchain/silentdatarollup-ethers-provider": minor
+"@appliedblockchain/silentdatarollup-ethers-provider-fireblocks": minor
+"@appliedblockchain/silentdatarollup-hardhat-plugin": minor
+"@appliedblockchain/silentdatarollup-hardhat-plugin-fireblocks": minor
+"@appliedblockchain/silentdatarollup-hardhat3-plugin": minor
+"@appliedblockchain/silentdatarollup-viem": minor
+"@appliedblockchain/silentdatarollup-viem-fireblocks": minor
+---
+
+RD-1696: Remove inaccurate "production-ready" wording for UCEF in the Silent Data development skill docs (UCEF contracts have not been audited).

--- a/silentdata-development/SKILL.md
+++ b/silentdata-development/SKILL.md
@@ -259,7 +259,7 @@ for (const log of privateLogs) {
 
 ## UCEF - Confidential ERC-20 Framework
 
-For production-ready confidential tokens, use **UCEF** (Unopinionated Confidential ERC-20 Framework):
+For confidential tokens, use **UCEF** (Unopinionated Confidential ERC-20 Framework):
 
 ```solidity
 import "../extensions/UCEFOwned.sol";


### PR DESCRIPTION
## Context
Our `silentdata-development` skill currently refers to UCEF as "production-ready", but the UCEF contracts have not been audited.

## Change
- Remove the "production-ready" wording from the UCEF section.
- Add a changeset (minor) documenting the docs change and the reason.

## Jira
- RD-1696: https://appliedblockchain.atlassian.net/browse/RD-1696
